### PR TITLE
support sidekiq 7.3 & 8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@
 
 ### Added
 
-- **Sidekiq 8.0+ support** - Full compatibility with Sidekiq 8.x releases
+- **Sidekiq 8.0+ support** - Full compatibility with Sidekiq 8.x releases (including 8.1+)
 - **New `Sidekiq::JobSignal.register_web_ui` helper method** - Automatically detects Sidekiq version and uses the appropriate Web UI registration pattern
-- **Version detection** - The gem automatically detects whether you're using Sidekiq 7.x or 8.0+ and handles registration accordingly
+- **Version detection** - The gem automatically detects whether you're using Sidekiq 7.x, 8.0, or 8.1+ and handles registration accordingly
 
 ### Changed
 
-- Updated Sidekiq dependency to support versions 7.3 through 8.x: `">= 7.3", "< 9.0"`
+- Updated Sidekiq dependency to support versions 7.3 through 8.1: `">= 7.3", "< 8.2"`
 - Updated required Ruby version to match Sidekiq 7.3 requirements: `">= 2.7.0"` (Note: Sidekiq 8.0+ requires Ruby 3.2+)
 - Enhanced README with comprehensive upgrade guide and migration instructions
 - Updated Web UI registration documentation to show all supported patterns
@@ -45,8 +45,12 @@ The core middleware and Redis operations were already compliant with Sidekiq 7.3
 
 The main changes were:
 1. Updating version constraints in gemspec
-2. Adding Web UI registration helper with version detection
+2. Adding Web UI registration helper with version detection for Sidekiq 7.x, 8.0, and 8.1+
 3. Comprehensive documentation updates
+
+**Sidekiq Version Support:**
+- Sidekiq 7.x: Uses `Sidekiq::Web.register()`
+- Sidekiq 8.1+: Uses `config.register_extension()` with keyword arguments
 
 ## [0.1.0] - 2023-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,53 @@
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-06
+
+### Breaking Changes
+
+- **Minimum Ruby version increased to 2.7.0** (was 2.6.0)
+- **Minimum Sidekiq version increased to 7.3** (was 6.5)
+- **Dropped support for Sidekiq 6.x** - Users on Sidekiq 6.x should stay on sidekiq-job-signal 0.1.x
+- **Note**: Sidekiq 8.0+ requires Ruby 3.2+, enforced by Sidekiq itself
+
+### Added
+
+- **Sidekiq 8.0+ support** - Full compatibility with Sidekiq 8.x releases
+- **New `Sidekiq::JobSignal.register_web_ui` helper method** - Automatically detects Sidekiq version and uses the appropriate Web UI registration pattern
+- **Version detection** - The gem automatically detects whether you're using Sidekiq 7.x or 8.0+ and handles registration accordingly
+
+### Changed
+
+- Updated Sidekiq dependency to support versions 7.3 through 8.x: `">= 7.3", "< 9.0"`
+- Updated required Ruby version to match Sidekiq 7.3 requirements: `">= 2.7.0"` (Note: Sidekiq 8.0+ requires Ruby 3.2+)
+- Enhanced README with comprehensive upgrade guide and migration instructions
+- Updated Web UI registration documentation to show all supported patterns
+
+### Migration Guide
+
+1. Ensure you're on Ruby 2.7 or higher (Ruby 3.2+ required if using Sidekiq 8.0+)
+2. Upgrade Sidekiq to 7.3 or higher: `bundle update sidekiq`
+3. Update sidekiq-job-signal to 0.2.0: `bundle update sidekiq-job-signal`
+4. (Optional) Update your Web UI registration to use the new helper method:
+   ```ruby
+   # Old (still works):
+   Sidekiq::Web.register Sidekiq::JobSignal::Web
+
+   # New (recommended):
+   Sidekiq::JobSignal.register_web_ui
+   ```
+
+### Technical Details
+
+The core middleware and Redis operations were already compliant with Sidekiq 7.3+ and 8.0+ APIs:
+- Already using modern Redis pipelining syntax: `r.pipelined do |pipeline|`
+- Already using correct ServerMiddleware API with proper `call(job, job_payload, queue)` signature
+- Only accesses stable job properties (`jid`, `class.name`) unaffected by internal changes
+
+The main changes were:
+1. Updating version constraints in gemspec
+2. Adding Web UI registration helper with version detection
+3. Comprehensive documentation updates
+
 ## [0.1.0] - 2023-04-02
 
 - Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,6 @@ gem "rspec", "~> 3.0"
 
 gem "standard", "~> 1.3"
 
-gem "sidekiq", "~> 6.5"
+gem "sidekiq", "~> 7.3"
 
 gem "pry-byebug"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Signal a job to quit, and block the job from executing through middleware.
 ## Requirements
 
 - Ruby 2.7+ (Ruby 3.2+ required for Sidekiq 8.0+)
-- Sidekiq 7.3 - 8.x
+- Sidekiq 7.3 - 8.1.x
 - Redis 7.0+ (or compatible)
 
 ## Installation
@@ -64,15 +64,15 @@ end
 If you'd like to enable the Sidekiq Web UI for quitting jobs, you can include the following in some kind of initialization file. This will enable a new "Signals" tab.
 
 ```rb
-# Recommended: Use the helper method that works with both Sidekiq 7.x and 8.0+
+# Recommended: Use the helper method that works with Sidekiq 7.x, 8.0, and 8.1+
 Sidekiq::JobSignal.register_web_ui
 
-# Or for Sidekiq 8.0+ you can use the new configuration pattern directly:
+# Or for Sidekiq 8.1+ you can use the new extension pattern directly:
 Sidekiq::Web.configure do |config|
-  config.register(Sidekiq::JobSignal::Web)
+  config.register_extension(Sidekiq::JobSignal::Web, name: "Signals", tab: "signals", index: "signals")
 end
 
-# Or for Sidekiq 7.x you can use the legacy pattern (still supported):
+# Or for Sidekiq 7.x (legacy pattern):
 Sidekiq::Web.register(Sidekiq::JobSignal::Web)
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Signal a job to quit, and block the job from executing through middleware.
 
+## Requirements
+
+- Ruby 2.7+ (Ruby 3.2+ required for Sidekiq 8.0+)
+- Sidekiq 7.3 - 8.x
+- Redis 7.0+ (or compatible)
+
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:
@@ -58,7 +64,54 @@ end
 If you'd like to enable the Sidekiq Web UI for quitting jobs, you can include the following in some kind of initialization file. This will enable a new "Signals" tab.
 
 ```rb
-Sidekiq::Web.register Sidekiq::JobSignal::Web
+# Recommended: Use the helper method that works with both Sidekiq 7.x and 8.0+
+Sidekiq::JobSignal.register_web_ui
+
+# Or for Sidekiq 8.0+ you can use the new configuration pattern directly:
+Sidekiq::Web.configure do |config|
+  config.register(Sidekiq::JobSignal::Web)
+end
+
+# Or for Sidekiq 7.x you can use the legacy pattern (still supported):
+Sidekiq::Web.register(Sidekiq::JobSignal::Web)
+```
+
+## Upgrading from 0.1.x to 0.2.0
+
+Version 0.2.0 introduces breaking changes to support Sidekiq 7.3+ and 8.0+:
+
+### Breaking Changes
+
+1. **Minimum Ruby version increased**: Now requires Ruby 2.7+ (was 2.6+)
+2. **Minimum Sidekiq version increased**: Now requires Sidekiq 7.3+ (was 6.5+)
+3. **Dropped Sidekiq 6.x support**: If you're on Sidekiq 6.x, stay on sidekiq-job-signal 0.1.x
+
+### Migration Steps
+
+1. Ensure you're on Ruby 2.7 or higher (Ruby 3.2+ required if using Sidekiq 8.0+)
+2. Upgrade Sidekiq to 7.3 or higher: `bundle update sidekiq`
+3. Update sidekiq-job-signal to 0.2.0: `bundle update sidekiq-job-signal`
+4. (Optional) Update your Web UI registration to use the new helper method:
+   ```rb
+   # Old (still works):
+   Sidekiq::Web.register Sidekiq::JobSignal::Web
+
+   # New (recommended):
+   Sidekiq::JobSignal.register_web_ui
+   ```
+
+### What's New
+
+- **Sidekiq 8.0+ support**: Full compatibility with the latest Sidekiq 8.x releases
+- **Version detection**: The gem automatically detects your Sidekiq version and uses the appropriate Web UI registration method
+- **Helper method**: New `Sidekiq::JobSignal.register_web_ui` method for simplified Web UI setup
+
+### Staying on 0.1.x
+
+If you need to stay on Sidekiq 6.x or Ruby < 2.7, you can pin to version 0.1.x in your Gemfile:
+
+```rb
+gem "sidekiq-job-signal", "~> 0.1.0", require: "sidekiq/job_signal"
 ```
 
 ## Development

--- a/lib/sidekiq/job_signal.rb
+++ b/lib/sidekiq/job_signal.rb
@@ -44,6 +44,20 @@ module Sidekiq
         end
         results.include?("quit")
       end
+
+      # Helper method to register the Web UI with version detection
+      # Supports both Sidekiq 7.x and 8.0+ registration patterns
+      def register_web_ui
+        if defined?(::Sidekiq::Web) && ::Sidekiq::Web.respond_to?(:configure)
+          # Sidekiq 8.0+ pattern
+          ::Sidekiq::Web.configure do |config|
+            config.register(Sidekiq::JobSignal::Web)
+          end
+        elsif defined?(::Sidekiq::Web)
+          # Sidekiq 7.x pattern
+          ::Sidekiq::Web.register(Sidekiq::JobSignal::Web)
+        end
+      end
     end
   end
 end

--- a/lib/sidekiq/job_signal.rb
+++ b/lib/sidekiq/job_signal.rb
@@ -46,15 +46,22 @@ module Sidekiq
       end
 
       # Helper method to register the Web UI with version detection
-      # Supports both Sidekiq 7.x and 8.0+ registration patterns
+      # Supports Sidekiq 7.x and 8.x (8.0+) registration patterns
       def register_web_ui
-        if defined?(::Sidekiq::Web) && ::Sidekiq::Web.respond_to?(:configure)
-          # Sidekiq 8.0+ pattern
+        return unless defined?(::Sidekiq::Web)
+
+        if ::Sidekiq::Web.respond_to?(:configure)
+          # Sidekiq 8.0+ uses configure with register_extension
           ::Sidekiq::Web.configure do |config|
-            config.register(Sidekiq::JobSignal::Web)
+            config.register_extension(
+              Sidekiq::JobSignal::Web,
+              name: "Signals",
+              tab: "signals",
+              index: "signals"
+            )
           end
-        elsif defined?(::Sidekiq::Web)
-          # Sidekiq 7.x pattern
+        else
+          # Sidekiq 7.x uses direct register
           ::Sidekiq::Web.register(Sidekiq::JobSignal::Web)
         end
       end

--- a/lib/sidekiq/job_signal/version.rb
+++ b/lib/sidekiq/job_signal/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module JobSignal
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"
   end
 end

--- a/lib/sidekiq/job_signal/web.rb
+++ b/lib/sidekiq/job_signal/web.rb
@@ -14,7 +14,8 @@ module Sidekiq
           Sidekiq::JobSignal.quit(jid: params["quit"]) if params["quit"]
           render(:erb, File.read("#{ROOT}/views/signals.erb"))
         end
-        app.tabs["Signals"] = "signals"
+        # Sidekiq 7.x uses app.tabs, Sidekiq 8.x uses tab: keyword in register_extension
+        app.tabs["Signals"] = "signals" if app.respond_to?(:tabs)
       end
     end
   end

--- a/sidekiq-job-signal.gemspec
+++ b/sidekiq-job-signal.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", [">= 7.3", "< 9.0"]
+  spec.add_dependency "sidekiq", [">= 6.5", "< 8.2"]
 end

--- a/sidekiq-job-signal.gemspec
+++ b/sidekiq-job-signal.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.description = "Signal a job to quit, and block the job from executing through middleware."
   spec.homepage = "https://github.com/jpcamara/sidekiq-job-signal"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/jpcamara/sidekiq-job-signal"
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", [">= 6.5", "< 7.0"]
+  spec.add_dependency "sidekiq", [">= 7.3", "< 9.0"]
 end


### PR DESCRIPTION
## Summary

Adds support for Sidekiq 7.3 and 8.0+ while maintaining backward compatibility with existing APIs.

## Changes

- **Version**: Bumped to 0.2.0
- **Ruby requirement**: Updated to >= 2.7.0 (was 2.6.0)  
- **Sidekiq support**: Now supports 7.3 through 8.x (was 6.5-6.x)
- **New feature**: Added `Sidekiq::JobSignal.register_web_ui` helper with automatic version detection
- **Documentation**: Comprehensive upgrade guide and migration instructions

## Breaking Changes

- Dropped Sidekiq 6.x support
- Minimum Ruby version increased to 2.7+ 
  - Note: Sidekiq 8.0+ requires Ruby 3.2+, enforced by Sidekiq itself

## Why This Works

The core gem code was already compatible with Sidekiq 7.3+/8.0+ APIs:
- ✅ Redis pipelining already using modern syntax: `r.pipelined do |pipeline|`
- ✅ ServerMiddleware already using correct `call(job, job_payload, queue)` signature  
- ✅ Job handling only uses stable properties (`job.jid`, `job.class.name`)

Main changes required:
1. Version constraints (gemspec)
2. Web UI registration pattern (new in Sidekiq 8.0)
3. Documentation updates

## New Helper Method

Added `Sidekiq::JobSignal.register_web_ui` that automatically detects Sidekiq version:

```
# Recommended: Works with both Sidekiq 7.x and 8.0+
Sidekiq::JobSignal.register_web_ui

# Or use version-specific patterns directly:
# Sidekiq 8.0+: Sidekiq::Web.configure { |c| c.register(...) }
# Sidekiq 7.x: Sidekiq::Web.register(...)
```

## Testing

The implementation requires testing with:
- Ruby 2.7+ with Sidekiq 7.3
- Ruby 3.2+ with Sidekiq 8.0+

Test cases should verify:
- Core functionality (quit, quitting?, delete_signal)
- ServerMiddleware blocks signaled jobs
- Web UI registration works with all three patterns
- on_quit handlers fire correctly

## Documentation

- Added comprehensive upgrade guide in README
- Detailed CHANGELOG with migration steps
- Clear requirements section (Ruby 2.7+, Sidekiq 7.3-8.x)